### PR TITLE
Add builder cache support for remote libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This is the format of the configuration file, though the settings can be listed 
   "deviceFile":      <string or false>,        // Device code file. Default: "device.nut"
   "agentFile":       <string or false>,        // Agent code file. Default: "agent.nut"
   "tests":           <string or string array>, // Test file search pattern. Default: ["*.test.nut", "tests/**/*.test.nut"]
-  "builderCache":    <boolean>,                // Enable build cache ? Default: false
+  "builderCache":    <boolean>,                // Enable build cache? Default: false
   "stopOnFailure":   <boolean>,                // Stop tests execution on failure? Default: false
   "allowDisconnect": <boolean>,                // Keep the session alive on device disconnects? Default: false
   "timeout":         <number>                  // Async test methods timeout, seconds. Default: 10
@@ -482,15 +482,15 @@ class TestCase1 extends ImpTestCase {
 Use this command to run the tests:
 
 ```bash
-imptest test [-c <configuration_file>] [-g <credentials_file>] [-d] [testcase_pattern]
+imptest test [-c <configuration_file>] [-g <credentials_file>] [-b <builder_file>] [--builder-cache=true|false] [-d] [testcase_pattern]
 ```
 where:
 
 * `-c` &mdash; this option is used to provide a path to the Test Project Configuration file. A relative or absolute path can be used. If the `-c` option is left out, the `.imptest` file in the current directory is assumed.
 * `-g` &mdash; this option is used to provide a path to file with GitHub credentials. A relative or absolute path can be used. If the `-g` option is left out, the `.imptest-auth` file in the current directory is assumed.
 * `-b` &mdash; this option is used to provide a path to file with [Builder variables](https://github.com/electricimp/Builder#usage). A relative or absolute path can be used. If the `-b` option is left out, the `.imptest-builder` file in the current directory is assumed.
+* `--builder-cache` &mdash; enable (if *true*) / disable (if *false*) builder cache for this test run. If not specified, defined by the setting in the test project configuration.
 * `-d` &mdash; prints [debug output](#debug-mode), stores device and agent code.
-* `--builder-cache` &mdash; enable/disable builder cache for the current session.
 * `testcase_pattern` &mdash; a pattern for [selective test runs](#selective-test-runs).
 
 The *impTest* tool searches all files that match the filename patterns specified in the [Test Project Configuration](#test-project-configuration). The search starts with Project Home. The tool looks for all Test Cases (classes) in the files. All the test methods from those classes are considered as tests for the current Test Project.
@@ -551,16 +551,18 @@ In this case:
 **Note** An internal class can play the role of a test case. To denote this use case, put `"."` at the end of the filter. For example, `"imptest test :Inner.TestClass."` executes all test methods from the *Inner.TestClass* class.
 
 ### Builder cache
-Builder cache was intended to improve the build time and reduce the number of requests to external resources.
-It is possible to cache an external libs only and by default builder store them up to 24 hours in the `.builer-cache` folder.
 
-By default builder cache is disabled and it could be activated during project configuration process.
-But to enable or disable cache once you could use `--builde-cache` option:
+Builder cache is intended to improve the build time and reduce the number of requests to external resources.
+
+It is possible to cache external libraries only. Builder stores the cache up to 24 hours in the `.builer-cache` folder.
+
+By default builder cache is disabled and it can be activated during a [test project configuration generation](#project-configuration-generation).
+
+Also, it is possible to specify should the builder cache be enabled or disabled for every [test run](#running-tests). For example, to disable the cache:
 ```shell
 >imptest test --builder-cache=false
 ```
-
-There is no special imptest's option to remove builder cache. It should be dropped manually via :
+There is no special imptest's option or command to remove the builder cache. But you can do this manually. For example:
 ```shell
 >rm -rf .builder-cache
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There is one [**Test Project Configuration**](#test-project-configuration) file 
 
 All files located in Project Home (and in its subdirectories) are considered as files with Test Cases if their names match the patterns specified in Test Project Configuration.
 
-**Test Case** is a class inherited from the *ImpTestCase* class. There can be several Test Cases (classes) in a file. A Test Case (class) can contain several tests (methods), each of which should be prefixed *test*, eg. *testEverythingOk()*. 
+**Test Case** is a class inherited from the *ImpTestCase* class. There can be several Test Cases (classes) in a file. A Test Case (class) can contain several tests (methods), each of which should be prefixed *test*, eg. *testEverythingOk()*.
 
 In order to work with impTest you need to:
 
@@ -68,6 +68,7 @@ A configuration file is a JSON file that contains the following key-value pairs:
 | _agentFile_ | A path to a file with the agent source code that is deployed along with the tests. `false` is used if no additional code is needed |
 | _tests_ | A set of patterns that *impTest* uses to search for files with Test Cases. If `**` is alone in the path portion, then it matches zero or more directories and subdirectories that need to be searched. It does not crawl symlinked directories. The pattern default value is `["*.test.nut", "tests/**/*.test.nut"]`. Do not change this value if there is a plan to run [agent and device test code together](#tests-for-bi-directional-device-agent-communication) |
 | _stopOnFailure_ | Set this option to `true` if you want to stop an execution after a test failure. The default value is `false` |
+| _builderCache_ | Set this option to `true` if you want to enable the builder cache for remote libs. The default value is `false` |
 | _allowDisconnect_ | Set this option to `true` if you want the test sessions to stay alive on temporary device disconnect. The default value is `false` |
 | _timeout_ | A timeout period (in seconds) after which the tests are considered as failed. Asynchronous tests are interrupted. The default value is ten seconds |
 
@@ -80,9 +81,10 @@ This is the format of the configuration file, though the settings can be listed 
   "deviceFile":      <string or false>,        // Device code file. Default: "device.nut"
   "agentFile":       <string or false>,        // Agent code file. Default: "agent.nut"
   "tests":           <string or string array>, // Test file search pattern. Default: ["*.test.nut", "tests/**/*.test.nut"]
+  "builderCache":    <boolean>,                // Enable build cache ? Default: false
   "stopOnFailure":   <boolean>,                // Stop tests execution on failure? Default: false
   "allowDisconnect": <boolean>,                // Keep the session alive on device disconnects? Default: false
-  "timeout":         <number>                  // Async test methods timeout, seconds. Default: 10 
+  "timeout":         <number>                  // Async test methods timeout, seconds. Default: 10
 }
 ```
 
@@ -161,7 +163,7 @@ class MyTestCase extends ImpTestCase {
     function testAssertTrue() {
         this.assertTrue(true);
     }
-    
+
     function testAssertEqual() {
         this.assertEqual(1000 * 0.01, 100 * 0.1);
     }
@@ -176,16 +178,16 @@ To identify partners file uniquely, there are some restrictions imposed on the t
 
 The [Test case](#overview) class must be located either in the device code or the agent code, but not in both. Whichever of the two it is included in, that is the **TestFile** &mdash; the other file is the **PartnerFile**. Both of these files must be located in the same directory on the disk.
 
-**TestFile** and **PartnerFile** must be named as follows: `TestName.(agent|device)[.test].nut`, ie. they need to have the same `TestName` prefix and the same `.nut` suffix. 
+**TestFile** and **PartnerFile** must be named as follows: `TestName.(agent|device)[.test].nut`, ie. they need to have the same `TestName` prefix and the same `.nut` suffix.
 
-**TestFile** is indicated by the `.test` string in its filename; **PartnerFile** must not feature this string in the suffix. 
+**TestFile** is indicated by the `.test` string in its filename; **PartnerFile** must not feature this string in the suffix.
 
 The type of execution environment is indicated by either `.device` or `.agent` in the file name &mdash; if **TestFile** contains `.agent`, **PartnerFile** must have `.device`, and *vice versa*.
 
 For example, `"Test1.agent.test.nut"` (test file) and `"Test1.device.nut"` (partner file).
 
 Due to partner special naming **do not** change the default value of ["Test file search pattern"](#test-project-configuration).
- 
+
 Further examples of test extensions can be found at [sample7](./samples/sample7).
 
 ### Asynchronous Testing
@@ -208,7 +210,7 @@ function testSomethingAsynchronously() {
 
 ### Builder Language
 
-[*Builder*](https://github.com/electricimp/Builder) is supported by *impTest*. The *Builder* language combines a preprocessor with an expression language and advanced imports. 
+[*Builder*](https://github.com/electricimp/Builder) is supported by *impTest*. The *Builder* language combines a preprocessor with an expression language and advanced imports.
 
 #### Example
 
@@ -488,6 +490,7 @@ where:
 * `-g` &mdash; this option is used to provide a path to file with GitHub credentials. A relative or absolute path can be used. If the `-g` option is left out, the `.imptest-auth` file in the current directory is assumed.
 * `-b` &mdash; this option is used to provide a path to file with [Builder variables](https://github.com/electricimp/Builder#usage). A relative or absolute path can be used. If the `-b` option is left out, the `.imptest-builder` file in the current directory is assumed.
 * `-d` &mdash; prints [debug output](#debug-mode), stores device and agent code.
+* `--builder-cache` &mdash; enable/disable builder cache for the current session.
 * `testcase_pattern` &mdash; a pattern for [selective test runs](#selective-test-runs).
 
 The *impTest* tool searches all files that match the filename patterns specified in the [Test Project Configuration](#test-project-configuration). The search starts with Project Home. The tool looks for all Test Cases (classes) in the files. All the test methods from those classes are considered as tests for the current Test Project.
@@ -546,6 +549,21 @@ In this case:
 **Note** If no colon is present in the testcase filter, it is assumed that only the pattern for a file name is specified.
 
 **Note** An internal class can play the role of a test case. To denote this use case, put `"."` at the end of the filter. For example, `"imptest test :Inner.TestClass."` executes all test methods from the *Inner.TestClass* class.
+
+### Builder cache
+Builder cache was intended to improve the build time and reduce the number of requests to external resources.
+It is possible to cache an external libs only and by default builder store them up to 24 hours in the `.builer-cache` folder.
+
+By default builder cache is disabled and it could be activated during project configuration process.
+But to enable or disable cache once you could use `--builde-cache` option:
+```shell
+>imptest test --builder-cache=false
+```
+
+There is no special imptest's option to remove builder cache. It should be dropped manually via :
+```shell
+>rm -rf .builder-cache
+```
 
 ### Debug Mode
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imptest",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Electric Imp Test Runner",
   "main": "src/cli/imptest.js",
   "scripts": {
@@ -16,7 +16,7 @@
     "url": "https://github.com/electricimp/impTest.git"
   },
   "dependencies": {
-    "Builder": "^2.1.0",
+    "Builder": "^2.2.2",
     "cli-prompt": "^0.4.3",
     "cli-table": "^0.3.1",
     "colors": "^1.1.2",

--- a/spec/cli/test/builder-cache.spec.js
+++ b/spec/cli/test/builder-cache.spec.js
@@ -53,7 +53,7 @@ describe('TestCommand test suite for Builder cache scenario', () => {
   };
   removeCacheDir(".builder-cache");
 
-  it('should run a command', (done) => {
+  it('should run a command without cache option in the project config', (done) => {
     run({
       configPath:  '/fixtures/builder-cache/.imptest',
     }).then((res) => {
@@ -63,7 +63,7 @@ describe('TestCommand test suite for Builder cache scenario', () => {
     });
   });
 
-  it('should verify the output', (done) => {
+  it('should verify that there is no cache folder', (done) => {
     // todo: insert more checks here
     expect(commandSuccess).toBe(true);
     expect(commandOut).not.toBeEmptyString();
@@ -72,7 +72,7 @@ describe('TestCommand test suite for Builder cache scenario', () => {
     done();
   });
 
-  it('should run a command', (done) => {
+  it('should run a command to check that command line cache option has a higher priority than project config', (done) => {
     run({
       configPath:  '/fixtures/builder-cache/.imptest_cache_true',
       builderCache: false,
@@ -83,7 +83,7 @@ describe('TestCommand test suite for Builder cache scenario', () => {
     });
   });
 
-  it('should verify the output', (done) => {
+  it('should verify that there is no cache folder', (done) => {
     // todo: insert more checks here
     expect(commandSuccess).toBe(true);
     expect(commandOut).not.toBeEmptyString();
@@ -92,7 +92,7 @@ describe('TestCommand test suite for Builder cache scenario', () => {
     done();
   });
 
-  it('should run a command', (done) => {
+  it('should run a command with cache enabled', (done) => {
     run({
       configPath:  '/fixtures/builder-cache/.imptest_cache_false',
       builderCache: true,
@@ -103,7 +103,7 @@ describe('TestCommand test suite for Builder cache scenario', () => {
     });
   });
 
-  it('should verify the output', (done) => {
+  it('should verify that cache folder present', (done) => {
     // todo: insert more checks here
     expect(commandSuccess).toBe(true);
     expect(commandOut).not.toBeEmptyString();
@@ -111,4 +111,6 @@ describe('TestCommand test suite for Builder cache scenario', () => {
     expect(fs.existsSync(".builder-cache")).toBe(true);
     done();
   });
+
+  removeCacheDir(".builder-cache");
 });

--- a/spec/cli/test/builder-cache.spec.js
+++ b/spec/cli/test/builder-cache.spec.js
@@ -1,0 +1,114 @@
+// MIT License
+//
+// Copyright 2016 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+// Builder syntax tests
+
+'use strict';
+
+require('jasmine-expect');
+const fs = require('fs');
+const run = require('./run');
+
+describe('TestCommand test suite for Builder cache scenario', () => {
+  let commandOut = '',
+    commandSuccess = true;
+
+  beforeEach(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
+  });
+
+  // reset previous state
+  var removeCacheDir = function(path) {
+    if (fs.existsSync(path)) {
+      fs.readdirSync(path).forEach(function(file, index){
+        var cachedLib = path + "/" + file;
+        if (fs.lstatSync(cachedLib).isDirectory()) { // unexpected case
+          removeCacheDir(cachedLib);
+        } else // remove lib
+          fs.unlinkSync(cachedLib);
+      });
+      fs.rmdirSync(path);
+    }
+  };
+  removeCacheDir(".builder-cache");
+
+  it('should run a command', (done) => {
+    run({
+      configPath:  '/fixtures/builder-cache/.imptest',
+    }).then((res) => {
+      commandSuccess = res.success;
+      commandOut = res.out;
+      done();
+    });
+  });
+
+  it('should verify the output', (done) => {
+    // todo: insert more checks here
+    expect(commandSuccess).toBe(true);
+    expect(commandOut).not.toBeEmptyString();
+    expect(commandOut).toMatch(/Testing succeeded\n/);
+    expect(fs.existsSync(".builder-cache")).toBe(false);
+    done();
+  });
+
+  it('should run a command', (done) => {
+    run({
+      configPath:  '/fixtures/builder-cache/.imptest_cache_true',
+      builderCache: false,
+    }).then((res) => {
+      commandSuccess = res.success;
+      commandOut = res.out;
+      done();
+    });
+  });
+
+  it('should verify the output', (done) => {
+    // todo: insert more checks here
+    expect(commandSuccess).toBe(true);
+    expect(commandOut).not.toBeEmptyString();
+    expect(commandOut).toMatch(/Testing succeeded\n/);
+    expect(fs.existsSync(".builder-cache")).toBe(false);
+    done();
+  });
+
+  it('should run a command', (done) => {
+    run({
+      configPath:  '/fixtures/builder-cache/.imptest_cache_false',
+      builderCache: true,
+    }).then((res) => {
+      commandSuccess = res.success;
+      commandOut = res.out;
+      done();
+    });
+  });
+
+  it('should verify the output', (done) => {
+    // todo: insert more checks here
+    expect(commandSuccess).toBe(true);
+    expect(commandOut).not.toBeEmptyString();
+    expect(commandOut).toMatch(/Testing succeeded\n/);
+    expect(fs.existsSync(".builder-cache")).toBe(true);
+    done();
+  });
+});

--- a/spec/cli/test/fixtures/builder-cache/.imptest
+++ b/spec/cli/test/fixtures/builder-cache/.imptest
@@ -1,0 +1,11 @@
+{
+    "modelId": <modelId>,
+    "devices": <deviceIds>,
+    "agentFile": "myAgent.class.nut",
+    "deviceFile": "myDevice.class.nut",
+    "stopOnFailure": false,
+    "timeout": 40,
+    "tests": [
+        "tests/builder.agent.nut"
+    ]
+}

--- a/spec/cli/test/fixtures/builder-cache/.imptest_cache_false
+++ b/spec/cli/test/fixtures/builder-cache/.imptest_cache_false
@@ -1,0 +1,12 @@
+{
+    "modelId": <modelId>,
+    "devices": <deviceIds>,
+    "agentFile": "myAgent.class.nut",
+    "deviceFile": "myDevice.class.nut",
+    "builderCache": false,
+    "stopOnFailure": false,
+    "timeout": 40,
+    "tests": [
+        "tests/builder.agent.nut"
+    ]
+}

--- a/spec/cli/test/fixtures/builder-cache/.imptest_cache_true
+++ b/spec/cli/test/fixtures/builder-cache/.imptest_cache_true
@@ -1,0 +1,12 @@
+{
+    "modelId": <modelId>,
+    "devices": <deviceIds>,
+    "agentFile": "myAgent.class.nut",
+    "deviceFile": "myDevice.class.nut",
+    "builderCache": true,
+    "stopOnFailure": false,
+    "timeout": 40,
+    "tests": [
+        "tests/builder.agent.nut"
+    ]
+}

--- a/spec/cli/test/fixtures/builder-cache/myAgent.class.nut
+++ b/spec/cli/test/fixtures/builder-cache/myAgent.class.nut
@@ -1,0 +1,7 @@
+@include "github:electricimp/Serializer/Serializer.class.nut"
+
+class MyAgent {
+  _myTmp="MyAgent";
+  function myFunc() {
+  }
+}

--- a/spec/cli/test/fixtures/builder-cache/myDevice.class.nut
+++ b/spec/cli/test/fixtures/builder-cache/myDevice.class.nut
@@ -1,0 +1,5 @@
+@include "github:electricimp/Serializer/Serializer.class.nut"
+
+imp.wakeup(3.0, function(){
+      // Empty
+});

--- a/spec/cli/test/fixtures/builder-cache/tests/builder.agent.nut
+++ b/spec/cli/test/fixtures/builder-cache/tests/builder.agent.nut
@@ -1,0 +1,3 @@
+
+class AgentTestCase extends ImpTestCase {
+}

--- a/spec/cli/test/run.js
+++ b/spec/cli/test/run.js
@@ -66,6 +66,7 @@ function run(options) {
     command.testFrameworkFile = __dirname + '/../../../src/impUnit/index.nut';
     // todo: update device/model from tests config or use single config
     command.configPath = createTmpImpTestFile(__dirname + options.configPath);
+    command.builderCache = options.builderCache;
 
     // optional options
     options.testCaseFile !== undefined && (command.testCaseFile = options.testCaseFile);

--- a/src/cli/imptest-init.js
+++ b/src/cli/imptest-init.js
@@ -37,7 +37,6 @@ commander
   .option('-d, --debug', 'debug output')
   .option('-c, --config [path]', 'config file path [default: .imptest]', '.imptest')
   .option('-f, --force', 'overwrite existing configuration')
-  .option('    --builder-cache', 'enable/disable builder cache', true)
   .parse(process.argv);
 
 // bootstrap command
@@ -46,7 +45,6 @@ const command = new InitCommand();
 
 command.debug = parseBool(commander.debug);
 command.force = parseBool(commander.force);
-command.builderCache = parseBool(commander['builder-cache']);
 command.version = packageJson.version;
 command.configPath = commander.config;
 

--- a/src/cli/imptest-init.js
+++ b/src/cli/imptest-init.js
@@ -37,6 +37,7 @@ commander
   .option('-d, --debug', 'debug output')
   .option('-c, --config [path]', 'config file path [default: .imptest]', '.imptest')
   .option('-f, --force', 'overwrite existing configuration')
+  .option('    --builder-cache', 'enable/disable builder cache', true)
   .parse(process.argv);
 
 // bootstrap command
@@ -45,6 +46,7 @@ const command = new InitCommand();
 
 command.debug = parseBool(commander.debug);
 command.force = parseBool(commander.force);
+command.builderCache = parseBool(commander['builder-cache']);
 command.version = packageJson.version;
 command.configPath = commander.config;
 

--- a/src/cli/imptest-test.js
+++ b/src/cli/imptest-test.js
@@ -41,6 +41,7 @@ commander
   .option('-g, --github-config [path]', 'github credentials config file path [default: .imptest-auth]', '.imptest-auth')
   .option('-c, --config [path]', 'config file path [default: .imptest]', '.imptest')
   .option('-b, --builder-variables [path]', 'Builder variables file path [default: .imptest-builder]', '.imptest-builder')
+  .option('--builder-cache [enable]', 'enable/disable builder cache')
   .parse(process.argv);
 
 // bootstrap command
@@ -49,6 +50,7 @@ const command = new TestCommand();
 
 command.version = packageJson.version;
 command.debug = parseBool(commander.debug);
+command.builderCache = commander.builderCache != undefined ? parseBool(commander.builderCache) : null;
 command.testFrameworkFile = __dirname + '/../impUnit/index.nut';
 command.selectedTest = commander.args[0] || null;
 command.configPath = commander.config;

--- a/src/lib/Commands/InitCommand.js
+++ b/src/lib/Commands/InitCommand.js
@@ -312,6 +312,12 @@ class InitCommand extends AbstractCommand {
             'default': this._impTestFile.values.stopOnFailure ? 'yes' : 'no'
           },
           {
+            key: 'builderCache',
+            label: c.yellow('> Enable builder cache ?'),
+            type: 'boolean',
+            'default': this._impTestFile.values.builderCache ? 'yes' : 'no'
+          },
+          {
             key: 'allowDisconnect',
             label: c.yellow('> Continue session on disconnect?'),
             type: 'boolean',
@@ -326,6 +332,7 @@ class InitCommand extends AbstractCommand {
         ],
         (input) => {
           this._impTestFile.values.stopOnFailure = input.stopOnFailure;
+          this._impTestFile.values.builderCache = input.builderCache;
           this._impTestFile.values.allowDisconnect = input.allowDisconnect;
           this._impTestFile.values.timeout = parseFloat(input.timeout);
           resolve();
@@ -363,7 +370,7 @@ class InitCommand extends AbstractCommand {
         });
     });
   }
-  
+
   /**
    * Generate sample tests
    * @return {Promise}

--- a/src/lib/Commands/TestCommand/index.js
+++ b/src/lib/Commands/TestCommand/index.js
@@ -842,6 +842,8 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
                 this.__Builder.machine.readers.github.username = this.githubUser;
                 this.__Builder.machine.readers.github.token = this.githubToken;
             }
+            // command line option has higher priority than config option
+            this.__Builder.machine.useCache = this.builderCache != null ? (this.builderCache == true) : (this._impTestFile.values.builderCache == true);
         }
         return this.__Builder;
     }

--- a/src/lib/ImpTestFile.js
+++ b/src/lib/ImpTestFile.js
@@ -65,6 +65,7 @@ class ImpTestFile {
       agentFile: '',
       deviceFile: '',
       stopOnFailure: false,
+      builderCache: false,
       allowDisconnect: false,
       timeout: 30,
       tests: ['*.test.nut', 'tests/**/*.test.nut']


### PR DESCRIPTION
- Add project configuration option for the builder cache
- Add "--builder-cache" option for test session
- Modify README
- Change version to the 1.2.0
- Increase minimal version of the Builder ^2.2.2 (there is no cache support in the earlier versions)
- Add tests for the test and config options interaction