### PR TITLE
CSE-499 prevent imptest failure on server.error()

### DIFF
--- a/spec/cli/test/fixtures/server-error/.imptest
+++ b/spec/cli/test/fixtures/server-error/.imptest
@@ -1,0 +1,14 @@
+{
+    "modelId": <modelId>,
+    "devices": <deviceIds>,
+    "agentFile": "myAgent.class.nut",
+    "deviceFile": "myDevice.class.nut",
+    "stopOnFailure": false,
+    "timeout": 40,
+    "tests": [
+        "tests/server-error.agent.nut",
+        "tests/server-error2.agent.nut",
+        "tests/server-error.device.nut",
+        "tests/server-error2.device.nut"
+    ]
+}

--- a/spec/cli/test/fixtures/server-error/.imptest_check_exception
+++ b/spec/cli/test/fixtures/server-error/.imptest_check_exception
@@ -1,0 +1,11 @@
+{
+    "modelId": <modelId>,
+    "devices": <deviceIds>,
+    "agentFile": "myAgent.class.nut",
+    "deviceFile": null,
+    "stopOnFailure": false,
+    "timeout": 40,
+    "tests": [
+        "tests/server-throw-exception.agent.nut"
+    ]
+}

--- a/spec/cli/test/fixtures/server-error/.imptest_check_failure
+++ b/spec/cli/test/fixtures/server-error/.imptest_check_failure
@@ -1,0 +1,11 @@
+{
+    "modelId": <modelId>,
+    "devices": <deviceIds>,
+    "agentFile": "myAgent.class.nut",
+    "deviceFile": null,
+    "stopOnFailure": false,
+    "timeout": 40,
+    "tests": [
+        "tests/server-index-access-failure.agent.nut"
+    ]
+}

--- a/spec/cli/test/fixtures/server-error/myAgent.class.nut
+++ b/spec/cli/test/fixtures/server-error/myAgent.class.nut
@@ -1,5 +1,17 @@
 class AgentServerError {
   function sendError() {
-      server.error("Send server error");
+    server.error("Send server error");
+  }
+
+  // NOTE: imptest should fail on
+  //       this function call
+  function checkThrowException() {
+    throw "Check unhandled exception";
+  }
+
+  // NOTE: imptest should fail on
+  //       this function call
+  function checkFieldDoesNotExist() {
+    this.fieldDoesNotExists = true;
   }
 }

--- a/spec/cli/test/fixtures/server-error/myAgent.class.nut
+++ b/spec/cli/test/fixtures/server-error/myAgent.class.nut
@@ -1,0 +1,5 @@
+class AgentServerError {
+  function sendError() {
+      server.error("Send server error");
+  }
+}

--- a/spec/cli/test/fixtures/server-error/myDevice.class.nut
+++ b/spec/cli/test/fixtures/server-error/myDevice.class.nut
@@ -1,0 +1,5 @@
+class DeviceServerError {
+  function sendError() {
+      server.error("Send server error");
+  }
+}

--- a/spec/cli/test/fixtures/server-error/tests/server-error.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error.agent.nut
@@ -1,0 +1,10 @@
+
+class AgentTestCase extends ImpTestCase {
+  function testAgentServerError() {
+      assertTrue(10 > 1, "Simple assert");
+      local errorMaker = AgentServerError();
+      errorMaker.sendError();
+      this.error("There is no way to see this message in the log.");
+      assertTrue(10 > 1, "Agent's server error passed");
+  }
+}

--- a/spec/cli/test/fixtures/server-error/tests/server-error.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error.agent.nut
@@ -4,7 +4,6 @@ class AgentTestCase extends ImpTestCase {
       assertTrue(10 > 1, "Simple assert");
       local errorMaker = AgentServerError();
       errorMaker.sendError();
-      this.error("There is no way to see this message in the log.");
       assertTrue(10 > 1, "Agent's server error passed");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-error.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error.agent.nut
@@ -1,9 +1,7 @@
 
 class AgentTestCase extends ImpTestCase {
   function testAgentServerError() {
-      assertTrue(10 > 1, "Simple assert");
-      local errorMaker = AgentServerError();
-      errorMaker.sendError();
-      assertTrue(10 > 1, "Agent's server error passed");
+      AgentServerError().sendError();
+      assertTrue(true, "Should still get the line executed");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-error.device.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error.device.nut
@@ -1,9 +1,7 @@
 
 class DeviceTestCase extends ImpTestCase {
   function testDeviceServerError() {
-      assertTrue(10 > 1, "Simple assert");
-      local test = DeviceServerError();
-      test.sendError();
-      assertTrue(10 > 1, "Agent's server error passed");
+      DeviceServerError().sendError();
+      assertTrue(true, "Should still get the line executed");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-error.device.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error.device.nut
@@ -4,7 +4,6 @@ class DeviceTestCase extends ImpTestCase {
       assertTrue(10 > 1, "Simple assert");
       local test = DeviceServerError();
       test.sendError();
-      this.error("There is no way to see this message in the log.");
       assertTrue(10 > 1, "Agent's server error passed");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-error.device.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error.device.nut
@@ -1,0 +1,10 @@
+
+class DeviceTestCase extends ImpTestCase {
+  function testDeviceServerError() {
+      assertTrue(10 > 1, "Simple assert");
+      local test = DeviceServerError();
+      test.sendError();
+      this.error("There is no way to see this message in the log.");
+      assertTrue(10 > 1, "Agent's server error passed");
+  }
+}

--- a/spec/cli/test/fixtures/server-error/tests/server-error2.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error2.agent.nut
@@ -1,0 +1,10 @@
+
+class AgentTestCase2 extends ImpTestCase {
+  function testAgentServerError() {
+      assertTrue(10 > 1, "Simple assert");
+      local agent = AgentServerError();
+      agent.sendError();
+      this.error("There is no way to see this message in the log.");
+      assertTrue(10 > 1, "Agent's server error passed");
+  }
+}

--- a/spec/cli/test/fixtures/server-error/tests/server-error2.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error2.agent.nut
@@ -4,7 +4,6 @@ class AgentTestCase2 extends ImpTestCase {
       assertTrue(10 > 1, "Simple assert");
       local agent = AgentServerError();
       agent.sendError();
-      this.error("There is no way to see this message in the log.");
       assertTrue(10 > 1, "Agent's server error passed");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-error2.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error2.agent.nut
@@ -1,9 +1,7 @@
 
 class AgentTestCase2 extends ImpTestCase {
   function testAgentServerError() {
-      assertTrue(10 > 1, "Simple assert");
-      local agent = AgentServerError();
-      agent.sendError();
-      assertTrue(10 > 1, "Agent's server error passed");
+      AgentServerError().sendError();
+      assertTrue(true, "Should still get the line executed");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-error2.device.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error2.device.nut
@@ -4,7 +4,6 @@ class DeviceTestCase2 extends ImpTestCase {
       assertTrue(10 > 1, "Simple assert");
       local test = DeviceServerError();
       test.sendError();
-      this.error("There is no way to see this message in the log.");
       assertTrue(10 > 1, "Agent's server error passed");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-error2.device.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error2.device.nut
@@ -1,9 +1,7 @@
 
 class DeviceTestCase2 extends ImpTestCase {
   function testDeviceServerError() {
-      assertTrue(10 > 1, "Simple assert");
-      local test = DeviceServerError();
-      test.sendError();
-      assertTrue(10 > 1, "Agent's server error passed");
+      DeviceServerError().sendError();
+      assertTrue(true, "Should still get the line executed");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-error2.device.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-error2.device.nut
@@ -1,0 +1,10 @@
+
+class DeviceTestCase2 extends ImpTestCase {
+  function testDeviceServerError() {
+      assertTrue(10 > 1, "Simple assert");
+      local test = DeviceServerError();
+      test.sendError();
+      this.error("There is no way to see this message in the log.");
+      assertTrue(10 > 1, "Agent's server error passed");
+  }
+}

--- a/spec/cli/test/fixtures/server-error/tests/server-index-access-failure.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-index-access-failure.agent.nut
@@ -1,8 +1,7 @@
 
 class AgentTestCase extends ImpTestCase {
   function testAgentServerError() {
-      assertTrue(10 > 1, "Simple assert");
-      local errorMaker = AgentServerError();
-      errorMaker.checkFieldDoesNotExist();
+      AgentServerError().checkFieldDoesNotExist();
+      assertTrue(false, "This assert should never happen because of runtime error on the previous step.");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-index-access-failure.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-index-access-failure.agent.nut
@@ -2,6 +2,6 @@
 class AgentTestCase extends ImpTestCase {
   function testAgentServerError() {
       AgentServerError().checkFieldDoesNotExist();
-      assertTrue(false, "This assert should never happen because of runtime error on the previous step.");
+      assertTrue(true, "This check should never happen because of runtime error on the previous step.");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-index-access-failure.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-index-access-failure.agent.nut
@@ -2,6 +2,7 @@
 class AgentTestCase extends ImpTestCase {
   function testAgentServerError() {
       AgentServerError().checkFieldDoesNotExist();
-      assertTrue(true, "This check should never happen because of runtime error on the previous step.");
+      // should never get next line executed
+      server.error("If you see this message, something went wrong!!!");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-index-access-failure.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-index-access-failure.agent.nut
@@ -1,0 +1,8 @@
+
+class AgentTestCase extends ImpTestCase {
+  function testAgentServerError() {
+      assertTrue(10 > 1, "Simple assert");
+      local errorMaker = AgentServerError();
+      errorMaker.checkFieldDoesNotExist();
+  }
+}

--- a/spec/cli/test/fixtures/server-error/tests/server-throw-exception.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-throw-exception.agent.nut
@@ -2,6 +2,6 @@
 class AgentTestCase extends ImpTestCase {
   function testAgentServerError() {
       AgentServerError().checkThrowException();
-      assertTrue(false, "This assert should never happen because of runtime error on the previous step.");
+      assertTrue(true, "This check should never happen because of runtime error on the previous step.");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-throw-exception.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-throw-exception.agent.nut
@@ -1,0 +1,8 @@
+
+class AgentTestCase extends ImpTestCase {
+  function testAgentServerError() {
+      assertTrue(10 > 1, "Simple assert");
+      local errorMaker = AgentServerError();
+      errorMaker.checkThrowException();
+  }
+}

--- a/spec/cli/test/fixtures/server-error/tests/server-throw-exception.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-throw-exception.agent.nut
@@ -2,6 +2,7 @@
 class AgentTestCase extends ImpTestCase {
   function testAgentServerError() {
       AgentServerError().checkThrowException();
-      assertTrue(true, "This check should never happen because of runtime error on the previous step.");
+      // should never get next line executed
+      server.error("If you see this message, something went wrong!!!");
   }
 }

--- a/spec/cli/test/fixtures/server-error/tests/server-throw-exception.agent.nut
+++ b/spec/cli/test/fixtures/server-error/tests/server-throw-exception.agent.nut
@@ -1,8 +1,7 @@
 
 class AgentTestCase extends ImpTestCase {
   function testAgentServerError() {
-      assertTrue(10 > 1, "Simple assert");
-      local errorMaker = AgentServerError();
-      errorMaker.checkThrowException();
+      AgentServerError().checkThrowException();
+      assertTrue(false, "This assert should never happen because of runtime error on the previous step.");
   }
 }

--- a/spec/cli/test/server-error.spec.js
+++ b/spec/cli/test/server-error.spec.js
@@ -47,11 +47,47 @@ describe('TestCommand test server error scenario', () => {
     });
   });
 
-  it('should verify that there is no test failuer happen', (done) => {
-    // todo: insert more checks here
+  it('should verify that there is no test failure happen', (done) => {
     expect(commandSuccess).toBe(true);
     expect(commandOut).not.toBeEmptyString();
     expect(commandOut).toMatch(/Testing succeeded\n/);
+    done();
+  });
+
+  // Negative test cases
+  it('Should fail with field does not exist', (done) => {
+    run({
+      configPath:  '/fixtures/server-error/.imptest_check_failure',
+    }).then((res) => {
+      commandSuccess = res.success;
+      commandOut = res.out;
+      done();
+    });
+  });
+
+  it('check that test failed', (done) => {
+    expect(commandSuccess).toBe(false);
+    expect(commandOut).not.toBeEmptyString();
+    expect(commandOut).toMatch(/Testing failed\n/);
+    expect(commandOut).toMatch("the index 'fieldDoesNotExists' does not exist");
+    done();
+  });
+
+  it('Should fail with unhandled exception', (done) => {
+    run({
+      configPath:  '/fixtures/server-error/.imptest_check_exception',
+    }).then((res) => {
+      commandSuccess = res.success;
+      commandOut = res.out;
+      done();
+    });
+  });
+
+  it('check that test failed with unhandled exception', (done) => {
+    expect(commandSuccess).toBe(false);
+    expect(commandOut).not.toBeEmptyString();
+    expect(commandOut).toMatch(/Testing failed\n/);
+    expect(commandOut).toMatch("unhandled exception");
     done();
   });
 });

--- a/spec/cli/test/server-error.spec.js
+++ b/spec/cli/test/server-error.spec.js
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright 2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+// Builder syntax tests
+
+'use strict';
+
+require('jasmine-expect');
+const run = require('./run');
+
+describe('TestCommand test server error scenario', () => {
+  let commandOut = '',
+    commandSuccess = true;
+
+  beforeEach(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
+  });
+
+  it('should run files with agent and device test errors', (done) => {
+    run({
+      configPath:  '/fixtures/server-error/.imptest',
+    }).then((res) => {
+      commandSuccess = res.success;
+      commandOut = res.out;
+      done();
+    });
+  });
+
+  it('should verify that there is no test failuer happen', (done) => {
+    // todo: insert more checks here
+    expect(commandSuccess).toBe(true);
+    expect(commandOut).not.toBeEmptyString();
+    expect(commandOut).toMatch(/Testing succeeded\n/);
+    done();
+  });
+});

--- a/src/lib/Commands/TestCommand/index.js
+++ b/src/lib/Commands/TestCommand/index.js
@@ -591,7 +591,7 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
     // @protected
 
     _onError(error) {
-        var keepSuccessStatus = false;
+        var ignoreErrorLog = false;
 
         this._debug('Error type: ' + error.constructor.name);
 
@@ -616,13 +616,13 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
 
         } else if (error instanceof Session.Errors.DeviceRuntimeError) {
 
-            keepSuccessStatus = true;
+            ignoreErrorLog = true;
             this._testLine(c.red(error.message));
             this._stopSession = false;
 
         } else if (error instanceof Session.Errors.AgentRuntimeError) {
 
-            keepSuccessStatus = true;
+            ignoreErrorLog = true;
             this._testLine(c.red(error.message));
             this._stopSession = false;
 
@@ -684,7 +684,7 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
 
         }
 
-        if (this._session && !keepSuccessStatus) {
+        if (this._session && !ignoreErrorLog) {
             this._session.error = true;
         }
 
@@ -698,7 +698,7 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
         }
 
         // command has not succeeded
-        if (!keepSuccessStatus)
+        if (!ignoreErrorLog)
           this._success = false;
     }
 

--- a/src/lib/Commands/TestCommand/index.js
+++ b/src/lib/Commands/TestCommand/index.js
@@ -591,6 +591,8 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
     // @protected
 
     _onError(error) {
+        var keepSuccessStatus = false;
+
         this._debug('Error type: ' + error.constructor.name);
 
         if (error instanceof Session.Errors.TestMethodError) {
@@ -614,13 +616,15 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
 
         } else if (error instanceof Session.Errors.DeviceRuntimeError) {
 
+            keepSuccessStatus = true;
             this._testLine(c.red(error.message));
-            this._stopSession = true;
+            this._stopSession = false;
 
         } else if (error instanceof Session.Errors.AgentRuntimeError) {
 
+            keepSuccessStatus = true;
             this._testLine(c.red(error.message));
-            this._stopSession = true;
+            this._stopSession = false;
 
         } else if (error instanceof Session.Errors.DeviceError) {
 
@@ -680,7 +684,7 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
 
         }
 
-        if (this._session) {
+        if (this._session && !keepSuccessStatus) {
             this._session.error = true;
         }
 
@@ -694,7 +698,8 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
         }
 
         // command has not succeeded
-        this._success = false;
+        if (!keepSuccessStatus)
+          this._success = false;
     }
 
     // Log message


### PR DESCRIPTION
User could create a negative test cases which could lead to the server.error() messages in the logs therefore imptest should not fail in that case.